### PR TITLE
Add Ruby 3.1 and Rails 7 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,24 +26,34 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.6.6
-          - 2.7.2
-          - 3.0.0
+          - 2.6
+          - 2.7
+          - '3.0'
+          - 3.1
         rails:
-          - 6.1.3.1
-          - 6.0.3.4
-          - 5.2.4.4
+          - 7.0.1
+          - 6.1.3
+          - 6.0.3
+          - 5.2.4
           - 5.1.7
         database_url:
           - postgresql://postgres:password@localhost:5432/test
           - sqlite3:test_db
         exclude:
-          - ruby: 3.0.0
-            rails: 6.0.3.4
-          - ruby: 3.0.0
-            rails: 5.2.4.4
-          - ruby: 3.0.0
+          - ruby: '3.1'
+            rails: 6.0.3
+          - ruby: '3.1'
+            rails: 5.2.4
+          - ruby: '3.1'
             rails: 5.1.7
+          - ruby: '3.0'
+            rails: 6.0.3
+          - ruby: '3.0'
+            rails: 5.2.4
+          - ruby: '3.0'
+            rails: 5.1.7
+          - ruby: 2.6
+            rails: 7.0.1
           - database_url: postgresql://postgres:password@localhost:5432/test
             rails: 5.1.7
     env:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,7 @@ class TestApp < Rails::Application
   config.active_support.halt_callback_chains_on_return_false = false
   config.active_record.time_zone_aware_types = [:time, :datetime]
   config.active_record.belongs_to_required_by_default = false
-  unless Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 2 || Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1
+  if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 2
     config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -174,7 +174,10 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_inherited_calls_superclass
-    assert_equal(BaseResource.subclasses, [PersonResource, SpecialBaseResource])
+    subclasses = BaseResource.subclasses
+    assert_includes(subclasses, PersonResource)
+    assert_includes(subclasses, SpecialBaseResource)
+    assert_equal(2, subclasses.size)
   end
 
   def test_nil_model_class


### PR DESCRIPTION

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions